### PR TITLE
Update module resource name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# terraform-aws-grafana-s2s
+# terraform-aws-grafana
 Terraform Module to Create AWS and Grafana Resources for metrics viewing and alerting.

--- a/modules/aws_grafana_datasource/main.tf
+++ b/modules/aws_grafana_datasource/main.tf
@@ -1,11 +1,11 @@
-resource "grafana_data_source" "this" {
+resource "grafana_data_source" "cloudwatch" {
   count = var.enable_cloudwatch ? 1 : 0
   
   type = "cloudwatch"
   name = "${var.grafana_data_source_name}-cloudwatch"
 
   json_data_encoded = jsonencode({
-    defaultRegion = "us-east-1"
+    defaultRegion = var.region
     authType      = "keys"
   })
 
@@ -16,3 +16,4 @@ resource "grafana_data_source" "this" {
 
   depends_on = [ aws_iam_access_key.this ]
 }
+


### PR DESCRIPTION
I've changed the name of the grafana datasource resource from "this" to "cloudwatch" because this module will be used to potentially create multiple aws datasources.

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>