### PR TITLE
adding `sensitive` function to `secure_json_data_encoded` results in …

### DIFF
--- a/modules/aws_grafana_datasource/main.tf
+++ b/modules/aws_grafana_datasource/main.tf
@@ -9,10 +9,10 @@ resource "grafana_data_source" "cloudwatch" {
     authType      = "keys"
   })
 
-  secure_json_data_encoded = sensitive(jsonencode({
+  secure_json_data_encoded = jsonencode({
     accessKey = aws_iam_access_key.this.id
     secretKey = aws_iam_access_key.this.secret
-  }))
+  })
 
   depends_on = [aws_iam_access_key.this]
 }


### PR DESCRIPTION
…no json output.

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>