### PR TITLE
Updates For Grafana Cloud Use

### DIFF
--- a/modules/aws_grafana_datasource/README.MD
+++ b/modules/aws_grafana_datasource/README.MD
@@ -28,13 +28,12 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_iam_access_key.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_access_key) | resource |
 | [aws_iam_policy.cloudwatch_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_user.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
-| [aws_iam_user_policy_attachment.aws_xray_read_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
-| [aws_iam_user_policy_attachment.cloudwatch_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
-| [aws_iam_user_policy_attachment.prometheus_query_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
-| [aws_iam_user_policy_attachment.prometheus_remote_write_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
+| [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.aws_xray_read_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.cloudwatch_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.prometheus_query_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.prometheus_remote_write_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [grafana_data_source.cloudwatch](https://registry.terraform.io/providers/grafana/grafana/2.19.4/docs/resources/data_source) | resource |
 
 ## Inputs
@@ -44,7 +43,9 @@ No modules.
 | <a name="input_enable_amazon_prometheus"></a> [enable\_amazon\_prometheus](#input\_enable\_amazon\_prometheus) | control whether to enable amazon prometheus related resources are created | `bool` | `false` | no |
 | <a name="input_enable_cloudwatch"></a> [enable\_cloudwatch](#input\_enable\_cloudwatch) | control whether to enable cloudwatch related resources are created | `bool` | `false` | no |
 | <a name="input_enable_xray"></a> [enable\_xray](#input\_enable\_xray) | control whether to enable xray related resources are created | `bool` | `false` | no |
-| <a name="input_grafana_api_token"></a> [grafana\_api\_token](#input\_grafana\_api\_token) | value of the grafana api token | `string` | `""` | no |
+| <a name="input_grafana_aws_account_id"></a> [grafana\_aws\_account\_id](#input\_grafana\_aws\_account\_id) | value of the grafana aws account id | `string` | n/a | yes |
+| <a name="input_grafana_aws_external_id"></a> [grafana\_aws\_external\_id](#input\_grafana\_aws\_external\_id) | value of the grafana aws external id | `string` | n/a | yes |
+| <a name="input_grafana_cloud_api_token"></a> [grafana\_cloud\_api\_token](#input\_grafana\_cloud\_api\_token) | value of the grafana cloud api token | `string` | `""` | no |
 | <a name="input_grafana_data_source_name"></a> [grafana\_data\_source\_name](#input\_grafana\_data\_source\_name) | value of the grafana data source name | `string` | `"cloudwatch"` | no |
 | <a name="input_region"></a> [region](#input\_region) | value of the aws region | `string` | `"us-east-1"` | no |
 

--- a/modules/aws_grafana_datasource/iam.tf
+++ b/modules/aws_grafana_datasource/iam.tf
@@ -1,9 +1,10 @@
-resource "aws_iam_user" "this" {
-  name = "${var.grafana_data_source_name}-user"
-}
-
-resource "aws_iam_access_key" "this" {
-  user = aws_iam_user.this.name
+resource "aws_iam_role" "this" {
+  name = "${var.grafana_data_source_name}-role"
+  assume_role_policy = templatefile("${path.module}/policies/grafana_cloud_trust_policy.json", {
+    region                  = var.region
+    grafana_aws_account_id  = var.grafana_aws_account_id
+    grafana_aws_external_id = var.grafana_aws_external_id
+  })
 }
 
 # Cloudwatch IAM Policies if var.enable_cloudwatch is true
@@ -17,32 +18,32 @@ resource "aws_iam_policy" "cloudwatch_policy" {
   })
 }
 
-resource "aws_iam_user_policy_attachment" "cloudwatch_policy_attachment" {
+resource "aws_iam_role_policy_attachment" "cloudwatch_policy_attachment" {
   count = var.enable_cloudwatch ? 1 : 0
 
-  user       = aws_iam_user.this.name
+  role       = aws_iam_role.this.name
   policy_arn = aws_iam_policy.cloudwatch_policy[count.index].arn
 }
 
 # Promethus IAM Policies if var.enable_amazon_prometheus is true
-resource "aws_iam_user_policy_attachment" "prometheus_query_policy_attachment" {
+resource "aws_iam_role_policy_attachment" "prometheus_query_policy_attachment" {
   count = var.enable_amazon_prometheus ? 1 : 0
 
-  user       = aws_iam_user.this.name
+  role       = aws_iam_role.this.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonPrometheusQueryAccess"
 }
 
-resource "aws_iam_user_policy_attachment" "prometheus_remote_write_policy_attachment" {
+resource "aws_iam_role_policy_attachment" "prometheus_remote_write_policy_attachment" {
   count = var.enable_amazon_prometheus ? 1 : 0
 
-  user       = aws_iam_user.this.name
+  role       = aws_iam_role.this.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonPrometheusRemoteWriteAccess"
 }
 
 # X-Ray IAM Policies if var.enable_xray is true
-resource "aws_iam_user_policy_attachment" "aws_xray_read_policy_attachment" {
+resource "aws_iam_role_policy_attachment" "aws_xray_read_policy_attachment" {
   count = var.enable_xray ? 1 : 0
 
-  user       = aws_iam_user.this.name
+  role       = aws_iam_role.this.name
   policy_arn = "arn:aws:iam::aws:policy/AWSXrayReadOnlyAccess"
 }

--- a/modules/aws_grafana_datasource/main.tf
+++ b/modules/aws_grafana_datasource/main.tf
@@ -6,13 +6,7 @@ resource "grafana_data_source" "cloudwatch" {
 
   json_data_encoded = jsonencode({
     defaultRegion = var.region
-    authType      = "keys"
+    authType      = "grafana_assume_role"
+    assumeRoleArn = aws_iam_role.this.arn
   })
-
-  secure_json_data_encoded = jsonencode({
-    accessKey = aws_iam_access_key.this.id
-    secretKey = aws_iam_access_key.this.secret
-  })
-
-  depends_on = [aws_iam_access_key.this]
 }

--- a/modules/aws_grafana_datasource/policies/grafana_cloud_trust_policy.json
+++ b/modules/aws_grafana_datasource/policies/grafana_cloud_trust_policy.json
@@ -1,0 +1,17 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam::${grafana_aws_account_id}:root"
+            },
+            "Action": "sts:AssumeRole",
+            "Condition": {
+                "StringEquals": {
+                    "sts:ExternalId": "${grafana_aws_external_id}"
+                }
+            }
+        }
+    ]
+}

--- a/modules/aws_grafana_datasource/variables.tf
+++ b/modules/aws_grafana_datasource/variables.tf
@@ -16,10 +16,10 @@ variable "enable_cloudwatch" {
   description = "control whether to enable cloudwatch related resources are created"
 }
 
-variable "grafana_api_token" {
+variable "grafana_cloud_api_token" {
   type        = string
   default     = ""
-  description = "value of the grafana api token"
+  description = "value of the grafana cloud api token"
 }
 
 variable "enable_amazon_prometheus" {
@@ -32,5 +32,14 @@ variable "enable_xray" {
   type        = bool
   default     = false
   description = "control whether to enable xray related resources are created"
+}
 
+variable "grafana_aws_account_id" {
+  type        = string
+  description = "value of the grafana aws account id"
+}
+
+variable "grafana_aws_external_id" {
+  type        = string
+  description = "value of the grafana aws external id"
 }

--- a/modules/aws_grafana_datasource/versions.tf
+++ b/modules/aws_grafana_datasource/versions.tf
@@ -23,5 +23,5 @@ provider "grafana" {
   # Cloud version of Grafana
   url = "https://mediavine.grafana.net/"
   # not using var.grafana_api_token here because we don't want to break deploys
-  cloud_access_policy_token = var.grafana_cloud_api_token
+  auth = var.grafana_cloud_api_token
 }

--- a/modules/aws_grafana_datasource/versions.tf
+++ b/modules/aws_grafana_datasource/versions.tf
@@ -17,6 +17,11 @@ provider "aws" {
 }
 
 provider "grafana" {
-  url  = "https://monitoring.mv-ops.com/"
-  auth = var.grafana_api_token
+  # Commenting this out because this is the oss version of grafana
+  # url  = "https://monitoring.mv-ops.com/"
+
+  # Cloud version of Grafana
+  url = "https://mediavine.grafana.net/"
+  # not using var.grafana_api_token here because we don't want to break deploys
+  cloud_access_policy_token = var.grafana_cloud_api_token
 }

--- a/modules/ecs_fargate_grafana_dashboard/README.MD
+++ b/modules/ecs_fargate_grafana_dashboard/README.MD
@@ -46,7 +46,8 @@ No modules.
 | <a name="input_dashboard_uid"></a> [dashboard\_uid](#input\_dashboard\_uid) | unique identifier for the dashboard | `string` | `"cloudwatch-dashboard"` | no |
 | <a name="input_enable_overwrite_dashboard"></a> [enable\_overwrite\_dashboard](#input\_enable\_overwrite\_dashboard) | overwrite the dashboard if it exists | `bool` | `false` | no |
 | <a name="input_folder"></a> [folder](#input\_folder) | folder to place the dashboard in | `string` | `""` | no |
-| <a name="input_grafana_api_token"></a> [grafana\_api\_token](#input\_grafana\_api\_token) | API token for Grafana | `string` | n/a | yes |
+| <a name="input_grafana_cloud_api_token"></a> [grafana\_cloud\_api\_token](#input\_grafana\_cloud\_api\_token) | API token for Grafana Cloud | `string` | n/a | yes |
+| <a name="input_parent_folder_uid"></a> [parent\_folder\_uid](#input\_parent\_folder\_uid) | parent folder uid | `string` | `""` | no |
 | <a name="input_prevent_destroy_if_not_empty"></a> [prevent\_destroy\_if\_not\_empty](#input\_prevent\_destroy\_if\_not\_empty) | used for the grafana folder resource | `bool` | `true` | no |
 | <a name="input_region_query"></a> [region\_query](#input\_region\_query) | name of queriable regions | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
 

--- a/modules/ecs_fargate_grafana_dashboard/main.tf
+++ b/modules/ecs_fargate_grafana_dashboard/main.tf
@@ -31,6 +31,7 @@ resource "grafana_folder" "this" {
   count                        = var.create_folder ? 1 : 0
   title                        = "${var.dashboard_uid}-${random_string.this[0].result}"
   uid                          = "${var.dashboard_uid}-${random_string.this[0].result}-uid"
+  parent_folder_uid            = length(var.parent_folder_uid) > 0 ? var.parent_folder_uid : ""
   prevent_destroy_if_not_empty = var.prevent_destroy_if_not_empty
 }
 

--- a/modules/ecs_fargate_grafana_dashboard/templates/fargatedashboard.json.tpl
+++ b/modules/ecs_fargate_grafana_dashboard/templates/fargatedashboard.json.tpl
@@ -651,7 +651,7 @@
                 }
               ]
             },
-            "unit": "ms"
+            "unit": "s"
           },
           "overrides": []
         },

--- a/modules/ecs_fargate_grafana_dashboard/variables.tf
+++ b/modules/ecs_fargate_grafana_dashboard/variables.tf
@@ -34,9 +34,9 @@ variable "dashboard_uid" {
   description = "unique identifier for the dashboard"
 }
 
-variable "grafana_api_token" {
+variable "grafana_cloud_api_token" {
   type        = string
-  description = "API token for Grafana"
+  description = "API token for Grafana Cloud"
 }
 
 variable "folder" {
@@ -49,4 +49,10 @@ variable "prevent_destroy_if_not_empty" {
   type        = bool
   default     = true
   description = "used for the grafana folder resource"
+}
+
+variable "parent_folder_uid" {
+  type        = string
+  default     = ""
+  description = "parent folder uid"
 }

--- a/modules/ecs_fargate_grafana_dashboard/versions.tf
+++ b/modules/ecs_fargate_grafana_dashboard/versions.tf
@@ -22,6 +22,11 @@ terraform {
 }
 
 provider "grafana" {
-  url  = "https://monitoring.mv-ops.com/"
-  auth = var.grafana_api_token
+  # Commenting this out because this is the oss version of grafana
+  # url  = "https://monitoring.mv-ops.com/"
+
+  # Cloud version of Grafana
+  url = "https://mediavine.grafana.net/"
+  # not using var.grafana_api_token here because we don't want to break deploys
+  cloud_access_policy_token = var.grafana_cloud_api_token
 }

--- a/modules/ecs_fargate_grafana_dashboard/versions.tf
+++ b/modules/ecs_fargate_grafana_dashboard/versions.tf
@@ -28,5 +28,5 @@ provider "grafana" {
   # Cloud version of Grafana
   url = "https://mediavine.grafana.net/"
   # not using var.grafana_api_token here because we don't want to break deploys
-  cloud_access_policy_token = var.grafana_cloud_api_token
+  auth = var.grafana_cloud_api_token
 }

--- a/modules/postgres_grafana_dashboard/README.md
+++ b/modules/postgres_grafana_dashboard/README.md
@@ -90,7 +90,8 @@ No modules.
 | <a name="input_dbinstanceidentifier"></a> [dbinstanceidentifier](#input\_dbinstanceidentifier) | DB instance identity of the RDS instance | `list(string)` | n/a | yes |
 | <a name="input_enable_overwrite_dashboard"></a> [enable\_overwrite\_dashboard](#input\_enable\_overwrite\_dashboard) | overwrite the dashboard if it exists | `bool` | `false` | no |
 | <a name="input_folder"></a> [folder](#input\_folder) | folder to place the dashboard in | `string` | `""` | no |
-| <a name="input_grafana_api_token"></a> [grafana\_api\_token](#input\_grafana\_api\_token) | API token for Grafana | `string` | n/a | yes |
+| <a name="input_grafana_cloud_api_token"></a> [grafana\_cloud\_api\_token](#input\_grafana\_cloud\_api\_token) | API token for Grafana Cloud | `string` | n/a | yes |
+| <a name="input_parent_folder_uid"></a> [parent\_folder\_uid](#input\_parent\_folder\_uid) | parent folder uid | `string` | `""` | no |
 | <a name="input_postgres_data_source_name"></a> [postgres\_data\_source\_name](#input\_postgres\_data\_source\_name) | name of the postgres data source | `string` | `"postgres"` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS region | `list(string)` | n/a | yes |
 

--- a/modules/postgres_grafana_dashboard/main.tf
+++ b/modules/postgres_grafana_dashboard/main.tf
@@ -35,6 +35,7 @@ resource "grafana_folder" "this" {
   count                        = var.create_folder ? 1 : 0
   title                        = "${var.dashboard_uid}-${random_string.this[0].result}"
   uid                          = "${var.dashboard_uid}-${random_string.this[0].result}-uid"
+  parent_folder_uid            = length(var.parent_folder_uid) > 0 ? var.parent_folder_uid : ""
   prevent_destroy_if_not_empty = true
 }
 

--- a/modules/postgres_grafana_dashboard/variables.tf
+++ b/modules/postgres_grafana_dashboard/variables.tf
@@ -1,6 +1,6 @@
-variable "grafana_api_token" {
+variable "grafana_cloud_api_token" {
   type        = string
-  description = "API token for Grafana"
+  description = "API token for Grafana Cloud"
 }
 
 variable "postgres_data_source_name" {
@@ -46,4 +46,10 @@ variable "enable_overwrite_dashboard" {
 variable "database_name" {
   type        = string
   description = "name of the database"
+}
+
+variable "parent_folder_uid" {
+  type        = string
+  default     = ""
+  description = "parent folder uid"
 }

--- a/modules/postgres_grafana_dashboard/versions.tf
+++ b/modules/postgres_grafana_dashboard/versions.tf
@@ -21,10 +21,13 @@ terraform {
   }
 }
 
-# provider "aws" {
-# }
 
 provider "grafana" {
-  url  = "https://monitoring.mv-ops.com/"
-  auth = var.grafana_api_token
+  # Commenting this out because this is the oss version of grafana
+  # url  = "https://monitoring.mv-ops.com/"
+
+  # Cloud version of Grafana
+  url = "https://mediavine.grafana.net/"
+  # not using var.grafana_api_token here because we don't want to break deploys
+  cloud_access_policy_token = var.grafana_cloud_api_token
 }

--- a/modules/postgres_grafana_dashboard/versions.tf
+++ b/modules/postgres_grafana_dashboard/versions.tf
@@ -29,5 +29,5 @@ provider "grafana" {
   # Cloud version of Grafana
   url = "https://mediavine.grafana.net/"
   # not using var.grafana_api_token here because we don't want to break deploys
-  cloud_access_policy_token = var.grafana_cloud_api_token
+  auth = var.grafana_cloud_api_token
 }

--- a/modules/postgres_grafana_datasource/README.md
+++ b/modules/postgres_grafana_datasource/README.md
@@ -95,7 +95,7 @@ No modules.
 | <a name="input_conn_max_lifetime"></a> [conn\_max\_lifetime](#input\_conn\_max\_lifetime) | The maximum amount of time in seconds a connection may be reused | `number` | n/a | yes |
 | <a name="input_database"></a> [database](#input\_database) | Name of the database | `string` | n/a | yes |
 | <a name="input_expected_version"></a> [expected\_version](#input\_expected\_version) | version of the database | `string` | n/a | yes |
-| <a name="input_grafana_api_token"></a> [grafana\_api\_token](#input\_grafana\_api\_token) | API token for Grafana | `string` | n/a | yes |
+| <a name="input_grafana_cloud_api_token"></a> [grafana\_cloud\_api\_token](#input\_grafana\_cloud\_api\_token) | API token for Grafana Cloud | `string` | n/a | yes |
 | <a name="input_grafana_data_source_name"></a> [grafana\_data\_source\_name](#input\_grafana\_data\_source\_name) | value of the grafana data source name | `string` | n/a | yes |
 | <a name="input_host"></a> [host](#input\_host) | Host of the database | `string` | n/a | yes |
 | <a name="input_master_password"></a> [master\_password](#input\_master\_password) | Password used to connect to existing database user | `string` | n/a | yes |

--- a/modules/postgres_grafana_datasource/variables.tf
+++ b/modules/postgres_grafana_datasource/variables.tf
@@ -1,6 +1,6 @@
-variable "grafana_api_token" {
+variable "grafana_cloud_api_token" {
   type        = string
-  description = "API token for Grafana"
+  description = "API token for Grafana Cloud"
 }
 
 variable "grafana_data_source_name" {

--- a/modules/postgres_grafana_datasource/versions.tf
+++ b/modules/postgres_grafana_datasource/versions.tf
@@ -41,5 +41,5 @@ provider "grafana" {
   # Cloud version of Grafana
   url = "https://mediavine.grafana.net/"
   # not using var.grafana_api_token here because we don't want to break deploys
-  cloud_access_policy_token = var.grafana_cloud_api_token
+  auth = var.grafana_cloud_api_token
 }

--- a/modules/postgres_grafana_datasource/versions.tf
+++ b/modules/postgres_grafana_datasource/versions.tf
@@ -35,6 +35,11 @@ provider "postgresql" {
 # }
 
 provider "grafana" {
-  url  = "https://monitoring.mv-ops.com/"
-  auth = var.grafana_api_token
+  # Commenting this out because this is the oss version of grafana
+  # url  = "https://monitoring.mv-ops.com/"
+
+  # Cloud version of Grafana
+  url = "https://mediavine.grafana.net/"
+  # not using var.grafana_api_token here because we don't want to break deploys
+  cloud_access_policy_token = var.grafana_cloud_api_token
 }


### PR DESCRIPTION
# Changes

## Breaking Changes
- Includes updates to grafana provider for all modules. This includes the endpoint change and change to api token variable name
- Cloudwatch Datasource uses IAM role instead of user. Adds additional variables needed to support Grafana assume role and adds a trust policy in addition to the existing cloudwatch policy.

# Minor Changes
Corrects the unit for target response times from a `ms` --> `s`